### PR TITLE
prevent double destroy of pollset

### DIFF
--- a/src/core/iomgr/pollset_posix.h
+++ b/src/core/iomgr/pollset_posix.h
@@ -56,6 +56,7 @@ typedef struct grpc_pollset {
   int counter;
   int in_flight_cbs;
   int shutting_down;
+  int called_shutdown;
   void (*shutdown_done_cb)(void *arg);
   void *shutdown_done_arg;
   union {


### PR DESCRIPTION
fixes crash in C# StartAndShutdownServer test