### PR TITLE
C# unknown method handler no longer needs to finish the request stream

### DIFF
--- a/src/csharp/Grpc.Core/Internal/AsyncCallServer.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallServer.cs
@@ -107,6 +107,7 @@ namespace Grpc.Core.Internal
 
                 call.StartSendStatusFromServer(status, HandleHalfclosed);
                 halfcloseRequested = true;
+                readingDone = true;
                 sendCompletionDelegate = completionDelegate;
             }
         }

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -267,8 +267,6 @@ namespace Grpc.Core.Internal
             var responseStream = new ServerResponseStream<byte[], byte[]>(asyncCall);
 
             await responseStream.WriteStatusAsync(new Status(StatusCode.Unimplemented, "No such method."));
-            // TODO(jtattermusch): if we don't read what client has sent, the server call never gets disposed.
-            await requestStream.ToList();
             await finishedTask;
         }
     }


### PR DESCRIPTION
After this, C# is pretty stable with one exception:

It looks like the changes to semantics of SendStatusFromServer() somehow influenced the status code that is returned from the call on the serverside:

In test math.Tests.MathClientServerTest.DivByZero (where the handler throws an exception which results in sending status code Unknown to client - and I checked this is what is being sent)  the client receives status "Cancelled" sometimes.

Similar thing happens with Grpc.Core.Tests.ClientServerTest.UnknownMethodHandler:
Test Failure : Grpc.Core.Tests.ClientServerTest.UnknownMethodHandler
     Expected: Unimplemented
     But was:  Unknown

Strange, isn't it?