### PR TITLE
Make Node extension work with slice changes

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -839,6 +839,7 @@
         "src/node/ext/node_grpc.cc",
         "src/node/ext/server.cc",
         "src/node/ext/server_credentials.cc",
+        "src/node/ext/slice.cc",
         "src/node/ext/timeval.cc",
       ],
       "dependencies": [

--- a/build.yaml
+++ b/build.yaml
@@ -3818,6 +3818,7 @@ node_modules:
   - src/node/ext/completion_queue_async_worker.h
   - src/node/ext/server.h
   - src/node/ext/server_credentials.h
+  - src/node/ext/slice.h
   - src/node/ext/timeval.h
   js:
   - src/node/index.js
@@ -3839,6 +3840,7 @@ node_modules:
   - src/node/ext/node_grpc.cc
   - src/node/ext/server.cc
   - src/node/ext/server_credentials.cc
+  - src/node/ext/slice.cc
   - src/node/ext/timeval.cc
 openssl_fallback:
   base_uri: https://openssl.org/source/old/1.0.2/

--- a/grpc.def
+++ b/grpc.def
@@ -164,6 +164,7 @@ EXPORTS
     grpc_slice_hash
     grpc_slice_is_equivalent
     grpc_slice_dup
+    grpc_slice_to_c_string
     grpc_slice_buffer_init
     grpc_slice_buffer_destroy
     grpc_slice_buffer_add

--- a/src/core/lib/iomgr/tcp_uv.c
+++ b/src/core/lib/iomgr/tcp_uv.c
@@ -48,6 +48,7 @@
 #include "src/core/lib/iomgr/network_status_tracker.h"
 #include "src/core/lib/iomgr/resource_quota.h"
 #include "src/core/lib/iomgr/tcp_uv.h"
+#include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/slice/slice_string_helpers.h"
 #include "src/core/lib/support/string.h"
 

--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -40,6 +40,7 @@
 #include "grpc/slice.h"
 
 #include "byte_buffer.h"
+#include "slice.h"
 
 namespace grpc {
 namespace node {
@@ -54,10 +55,7 @@ using v8::Value;
 
 grpc_byte_buffer *BufferToByteBuffer(Local<Value> buffer) {
   Nan::HandleScope scope;
-  int length = ::node::Buffer::Length(buffer);
-  char *data = ::node::Buffer::Data(buffer);
-  grpc_slice slice = grpc_slice_malloc(length);
-  memcpy(GRPC_SLICE_START_PTR(slice), data, length);
+  grpc_slice slice = CreateSliceFromBuffer(buffer);
   grpc_byte_buffer *byte_buffer(grpc_raw_byte_buffer_create(&slice, 1));
   grpc_slice_unref(slice);
   return byte_buffer;

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -48,6 +48,7 @@
 #include "completion_queue.h"
 #include "completion_queue_async_worker.h"
 #include "call_credentials.h"
+#include "slice.h"
 #include "timeval.h"
 
 using std::unique_ptr;
@@ -96,8 +97,7 @@ Local<Value> nanErrorWithCode(const char *msg, grpc_call_error code) {
   return scope.Escape(err);
 }
 
-bool CreateMetadataArray(Local<Object> metadata, grpc_metadata_array *array,
-                         shared_ptr<Resources> resources) {
+bool CreateMetadataArray(Local<Object> metadata, grpc_metadata_array *array) {
   HandleScope scope;
   grpc_metadata_array_init(array);
   Local<Array> keys = Nan::GetOwnPropertyNames(metadata).ToLocalChecked();
@@ -113,32 +113,25 @@ bool CreateMetadataArray(Local<Object> metadata, grpc_metadata_array *array,
   array->metadata = reinterpret_cast<grpc_metadata*>(
       gpr_malloc(array->capacity * sizeof(grpc_metadata)));
   for (unsigned int i = 0; i < keys->Length(); i++) {
-    Local<String> current_key(keys->Get(i)->ToString());
-    Utf8String *utf8_key = new Utf8String(current_key);
-    resources->strings.push_back(unique_ptr<Utf8String>(utf8_key));
+    Local<String> current_key(Nan::To<String>(keys->Get(i)).ToLocalChecked());
     Local<Array> values = Local<Array>::Cast(
         Nan::Get(metadata, current_key).ToLocalChecked());
+    grpc_slice key_slice = grpc_slice_intern(CreateSliceFromString(current_key));
     for (unsigned int j = 0; j < values->Length(); j++) {
       Local<Value> value = Nan::Get(values, j).ToLocalChecked();
       grpc_metadata *current = &array->metadata[array->count];
-      current->key = **utf8_key;
+      current->key = key_slice;
       // Only allow binary headers for "-bin" keys
-      if (grpc_is_binary_header(current->key, strlen(current->key))) {
+      if (grpc_is_binary_header(key_slice)) {
         if (::node::Buffer::HasInstance(value)) {
-          current->value = ::node::Buffer::Data(value);
-          current->value_length = ::node::Buffer::Length(value);
-          PersistentValue *handle = new PersistentValue(value);
-          resources->handles.push_back(unique_ptr<PersistentValue>(handle));
+          current->value = CreateSliceFromBuffer(value);
         } else {
           return false;
         }
       } else {
         if (value->IsString()) {
           Local<String> string_value = Nan::To<String>(value).ToLocalChecked();
-          Utf8String *utf8_value = new Utf8String(string_value);
-          resources->strings.push_back(unique_ptr<Utf8String>(utf8_value));
-          current->value = **utf8_value;
-          current->value_length = string_value->Length();
+          current->value = CreateSliceFromString(string_value);
         } else {
           return false;
         }
@@ -153,40 +146,25 @@ Local<Value> ParseMetadata(const grpc_metadata_array *metadata_array) {
   EscapableHandleScope scope;
   grpc_metadata *metadata_elements = metadata_array->metadata;
   size_t length = metadata_array->count;
-  std::map<const char*, size_t> size_map;
-  std::map<const char*, size_t> index_map;
-
-  for (unsigned int i = 0; i < length; i++) {
-    const char *key = metadata_elements[i].key;
-    if (size_map.count(key)) {
-      size_map[key] += 1;
-    } else {
-      size_map[key] = 1;
-    }
-    index_map[key] = 0;
-  }
   Local<Object> metadata_object = Nan::New<Object>();
   for (unsigned int i = 0; i < length; i++) {
     grpc_metadata* elem = &metadata_elements[i];
-    Local<String> key_string = Nan::New(elem->key).ToLocalChecked();
+    // TODO(murgatroid99): Use zero-copy string construction instead
+    Local<String> key_string = CopyStringFromSlice(elem->key);
     Local<Array> array;
     MaybeLocal<Value> maybe_array = Nan::Get(metadata_object, key_string);
     if (maybe_array.IsEmpty() || !maybe_array.ToLocalChecked()->IsArray()) {
-      array = Nan::New<Array>(size_map[elem->key]);
+      array = Nan::New<Array>(0);
       Nan::Set(metadata_object, key_string, array);
     } else {
       array = Local<Array>::Cast(maybe_array.ToLocalChecked());
     }
-    if (grpc_is_binary_header(elem->key, strlen(elem->key))) {
-      Nan::Set(array, index_map[elem->key],
-               MakeFastBuffer(
-                   Nan::CopyBuffer(elem->value,
-                                   elem->value_length).ToLocalChecked()));
+    if (grpc_is_binary_header(elem->key)) {
+      Nan::Set(array, array->Length(), CreateBufferFromSlice(elem->value));
     } else {
-      Nan::Set(array, index_map[elem->key],
-               Nan::New(elem->value).ToLocalChecked());
+      // TODO(murgatroid99): Use zero-copy string construction instead
+      Nan::Set(array, array->Length(), CopyStringFromSlice(elem->value));
     }
-    index_map[elem->key] += 1;
   }
   return scope.Escape(metadata_object);
 }
@@ -205,8 +183,7 @@ class SendMetadataOp : public Op {
     EscapableHandleScope scope;
     return scope.Escape(Nan::True());
   }
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     if (!value->IsObject()) {
       return false;
     }
@@ -216,7 +193,7 @@ class SendMetadataOp : public Op {
       return false;
     }
     if (!CreateMetadataArray(maybe_metadata.ToLocalChecked(),
-                             &array, resources)) {
+                             &array)) {
       return false;
     }
     out->data.send_initial_metadata.count = array.count;
@@ -246,8 +223,7 @@ class SendMessageOp : public Op {
     EscapableHandleScope scope;
     return scope.Escape(Nan::True());
   }
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     if (!::node::Buffer::HasInstance(value)) {
       return false;
     }
@@ -263,8 +239,6 @@ class SendMessageOp : public Op {
     }
     send_message = BufferToByteBuffer(value);
     out->data.send_message = send_message;
-    PersistentValue *handle = new PersistentValue(value);
-    resources->handles.push_back(unique_ptr<PersistentValue>(handle));
     return true;
   }
   bool IsFinalOp() {
@@ -284,8 +258,7 @@ class SendClientCloseOp : public Op {
     EscapableHandleScope scope;
     return scope.Escape(Nan::True());
   }
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     return true;
   }
   bool IsFinalOp() {
@@ -299,12 +272,14 @@ class SendClientCloseOp : public Op {
 
 class SendServerStatusOp : public Op {
  public:
+  ~SendServerStatusOp() {
+    grpc_slice_unref(details);
+  }
   Local<Value> GetNodeValue() const {
     EscapableHandleScope scope;
     return scope.Escape(Nan::True());
   }
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     if (!value->IsObject()) {
       return false;
     }
@@ -339,16 +314,15 @@ class SendServerStatusOp : public Op {
     Local<String> details = Nan::To<String>(
         maybe_details.ToLocalChecked()).ToLocalChecked();
     grpc_metadata_array array;
-    if (!CreateMetadataArray(metadata, &array, resources)) {
+    if (!CreateMetadataArray(metadata, &array)) {
       return false;
     }
     out->data.send_status_from_server.trailing_metadata_count = array.count;
     out->data.send_status_from_server.trailing_metadata = array.metadata;
     out->data.send_status_from_server.status =
         static_cast<grpc_status_code>(code);
-    Utf8String *str = new Utf8String(details);
-    resources->strings.push_back(unique_ptr<Utf8String>(str));
-    out->data.send_status_from_server.status_details = **str;
+    this->details = CreateSliceFromString(details);
+    out->data.send_status_from_server.status_details = &this->details;
     return true;
   }
   bool IsFinalOp() {
@@ -358,6 +332,9 @@ class SendServerStatusOp : public Op {
   std::string GetTypeString() const {
     return "send_status";
   }
+
+ private:
+  grpc_slice details;
 };
 
 class GetMetadataOp : public Op {
@@ -375,8 +352,7 @@ class GetMetadataOp : public Op {
     return scope.Escape(ParseMetadata(&recv_metadata));
   }
 
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     out->data.recv_initial_metadata = &recv_metadata;
     return true;
   }
@@ -408,8 +384,7 @@ class ReadMessageOp : public Op {
     return scope.Escape(ByteBufferToBuffer(recv_message));
   }
 
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     out->data.recv_message = &recv_message;
     return true;
   }
@@ -430,21 +405,16 @@ class ClientStatusOp : public Op {
  public:
   ClientStatusOp() {
     grpc_metadata_array_init(&metadata_array);
-    status_details = NULL;
-    details_capacity = 0;
   }
 
   ~ClientStatusOp() {
     grpc_metadata_array_destroy(&metadata_array);
-    gpr_free(status_details);
   }
 
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     out->data.recv_status_on_client.trailing_metadata = &metadata_array;
     out->data.recv_status_on_client.status = &status;
     out->data.recv_status_on_client.status_details = &status_details;
-    out->data.recv_status_on_client.status_details_capacity = &details_capacity;
     return true;
   }
 
@@ -453,10 +423,8 @@ class ClientStatusOp : public Op {
     Local<Object> status_obj = Nan::New<Object>();
     Nan::Set(status_obj, Nan::New("code").ToLocalChecked(),
                     Nan::New<Number>(status));
-    if (status_details != NULL) {
-      Nan::Set(status_obj, Nan::New("details").ToLocalChecked(),
-               Nan::New(status_details).ToLocalChecked());
-    }
+    Nan::Set(status_obj, Nan::New("details").ToLocalChecked(),
+               CopyStringFromSlice(status_details));
     Nan::Set(status_obj, Nan::New("metadata").ToLocalChecked(),
              ParseMetadata(&metadata_array));
     return scope.Escape(status_obj);
@@ -471,8 +439,7 @@ class ClientStatusOp : public Op {
  private:
   grpc_metadata_array metadata_array;
   grpc_status_code status;
-  char *status_details;
-  size_t details_capacity;
+  grpc_slice status_details;
 };
 
 class ServerCloseResponseOp : public Op {
@@ -482,8 +449,7 @@ class ServerCloseResponseOp : public Op {
     return scope.Escape(Nan::New<Boolean>(cancelled));
   }
 
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     out->data.recv_close_on_server.cancelled = &cancelled;
     return true;
   }
@@ -500,9 +466,8 @@ class ServerCloseResponseOp : public Op {
   int cancelled;
 };
 
-tag::tag(Callback *callback, OpVec *ops,
-         shared_ptr<Resources> resources, Call *call) :
-    callback(callback), ops(ops), resources(resources), call(call){
+tag::tag(Callback *callback, OpVec *ops, Call *call) :
+    callback(callback), ops(ops), call(call){
 }
 
 tag::~tag() {
@@ -650,20 +615,24 @@ NAN_METHOD(Call::New) {
       if (channel->GetWrappedChannel() == NULL) {
         return Nan::ThrowError("Call cannot be created from a closed channel");
       }
-      Utf8String method(info[1]);
       double deadline = Nan::To<double>(info[2]).FromJust();
       grpc_channel *wrapped_channel = channel->GetWrappedChannel();
       grpc_call *wrapped_call;
       if (info[3]->IsString()) {
-        Utf8String host_override(info[3]);
+        grpc_slice *host = new grpc_slice;
+        *host = CreateSliceFromString(
+            Nan::To<String>(info[3]).ToLocalChecked());
         wrapped_call = grpc_channel_create_call(
             wrapped_channel, parent_call, propagate_flags,
-            GetCompletionQueue(), *method,
-            *host_override, MillisecondsToTimespec(deadline), NULL);
+            GetCompletionQueue(), CreateSliceFromString(
+                Nan::To<String>(info[1]).ToLocalChecked()),
+            host, MillisecondsToTimespec(deadline), NULL);
+        delete host;
       } else if (info[3]->IsUndefined() || info[3]->IsNull()) {
         wrapped_call = grpc_channel_create_call(
             wrapped_channel, parent_call, propagate_flags,
-            GetCompletionQueue(), *method,
+            GetCompletionQueue(), CreateSliceFromString(
+                Nan::To<String>(info[1]).ToLocalChecked()),
             NULL, MillisecondsToTimespec(deadline), NULL);
       } else {
         return Nan::ThrowTypeError("Call's fourth argument must be a string");
@@ -700,7 +669,6 @@ NAN_METHOD(Call::StartBatch) {
   }
   Local<Function> callback_func = info[1].As<Function>();
   Call *call = ObjectWrap::Unwrap<Call>(info.This());
-  shared_ptr<Resources> resources(new Resources);
   Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
   Local<Array> keys = Nan::GetOwnPropertyNames(obj).ToLocalChecked();
   size_t nops = keys->Length();
@@ -745,7 +713,7 @@ NAN_METHOD(Call::StartBatch) {
       default:
         return Nan::ThrowError("Argument object had an unrecognized key");
     }
-    if (!op->ParseOp(obj->Get(type), &ops[i], resources)) {
+    if (!op->ParseOp(obj->Get(type), &ops[i])) {
       return Nan::ThrowTypeError("Incorrectly typed arguments to startBatch");
     }
     op_vector->push_back(std::move(op));
@@ -753,7 +721,7 @@ NAN_METHOD(Call::StartBatch) {
   Callback *callback = new Callback(callback_func);
   grpc_call_error error = grpc_call_start_batch(
       call->wrapped_call, &ops[0], nops, new struct tag(
-          callback, op_vector.release(), resources, call), NULL);
+          callback, op_vector.release(), call), NULL);
   if (error != GRPC_CALL_OK) {
     return Nan::ThrowError(nanErrorWithCode("startBatch failed", error));
   }

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -51,20 +51,12 @@ namespace node {
 using std::unique_ptr;
 using std::shared_ptr;
 
-typedef Nan::Persistent<v8::Value, Nan::CopyablePersistentTraits<v8::Value>> PersistentValue;
-
 v8::Local<v8::Value> nanErrorWithCode(const char *msg, grpc_call_error code);
 
 v8::Local<v8::Value> ParseMetadata(const grpc_metadata_array *metadata_array);
 
-struct Resources {
-  std::vector<unique_ptr<Nan::Utf8String> > strings;
-  std::vector<unique_ptr<PersistentValue> > handles;
-};
-
 bool CreateMetadataArray(v8::Local<v8::Object> metadata,
-                         grpc_metadata_array *array,
-                         shared_ptr<Resources> resources);
+                         grpc_metadata_array *array);
 
 /* Wrapper class for grpc_call structs. */
 class Call : public Nan::ObjectWrap {
@@ -106,8 +98,7 @@ class Call : public Nan::ObjectWrap {
 class Op {
  public:
   virtual v8::Local<v8::Value> GetNodeValue() const = 0;
-  virtual bool ParseOp(v8::Local<v8::Value> value, grpc_op *out,
-                       shared_ptr<Resources> resources) = 0;
+  virtual bool ParseOp(v8::Local<v8::Value> value, grpc_op *out) = 0;
   virtual ~Op();
   v8::Local<v8::Value> GetOpType() const;
   virtual bool IsFinalOp() = 0;
@@ -118,12 +109,10 @@ class Op {
 
 typedef std::vector<unique_ptr<Op>> OpVec;
 struct tag {
-  tag(Nan::Callback *callback, OpVec *ops,
-      shared_ptr<Resources> resources, Call *call);
+  tag(Nan::Callback *callback, OpVec *ops, Call *call);
   ~tag();
   Nan::Callback *callback;
   OpVec *ops;
-  shared_ptr<Resources> resources;
   Call *call;
 };
 

--- a/src/node/ext/call_credentials.cc
+++ b/src/node/ext/call_credentials.cc
@@ -206,7 +206,6 @@ NAN_METHOD(PluginCallback) {
     return Nan::ThrowTypeError(
         "The callback's fourth argument must be an object");
   }
-  shared_ptr<Resources> resources(new Resources);
   grpc_status_code code = static_cast<grpc_status_code>(
       Nan::To<uint32_t>(info[0]).FromJust());
   Utf8String details_utf8_str(info[1]);
@@ -214,7 +213,7 @@ NAN_METHOD(PluginCallback) {
   grpc_metadata_array array;
   Local<Object> callback_data = Nan::To<Object>(info[3]).ToLocalChecked();
   if (!CreateMetadataArray(Nan::To<Object>(info[2]).ToLocalChecked(),
-                           &array, resources)){
+                           &array)){
     return Nan::ThrowError("Failed to parse metadata");
   }
   grpc_credentials_plugin_metadata_cb cb =

--- a/src/node/ext/channel.cc
+++ b/src/node/ext/channel.cc
@@ -280,8 +280,7 @@ NAN_METHOD(Channel::WatchConnectivityState) {
       channel->wrapped_channel, last_state, MillisecondsToTimespec(deadline),
       GetCompletionQueue(),
       new struct tag(callback,
-                     ops.release(),
-                     shared_ptr<Resources>(nullptr), NULL));
+                     ops.release(), NULL));
   CompletionQueueNext();
 }
 

--- a/src/node/ext/node_grpc.cc
+++ b/src/node/ext/node_grpc.cc
@@ -56,8 +56,11 @@ extern "C" {
 #include "server.h"
 #include "completion_queue_async_worker.h"
 #include "server_credentials.h"
+#include "slice.h"
 #include "timeval.h"
 #include "completion_queue.h"
+
+using grpc::node::CreateSliceFromString;
 
 using v8::FunctionTemplate;
 using v8::Local;
@@ -283,10 +286,8 @@ NAN_METHOD(MetadataKeyIsLegal) {
         "headerKeyIsLegal's argument must be a string");
   }
   Local<String> key = Nan::To<String>(info[0]).ToLocalChecked();
-  Nan::Utf8String key_utf8_str(key);
-  char *key_str = *key_utf8_str;
   info.GetReturnValue().Set(static_cast<bool>(
-      grpc_header_key_is_legal(key_str, static_cast<size_t>(key->Length()))));
+      grpc_header_key_is_legal(CreateSliceFromString(key))));
 }
 
 NAN_METHOD(MetadataNonbinValueIsLegal) {
@@ -295,11 +296,8 @@ NAN_METHOD(MetadataNonbinValueIsLegal) {
         "metadataNonbinValueIsLegal's argument must be a string");
   }
   Local<String> value = Nan::To<String>(info[0]).ToLocalChecked();
-  Nan::Utf8String value_utf8_str(value);
-  char *value_str = *value_utf8_str;
   info.GetReturnValue().Set(static_cast<bool>(
-      grpc_header_nonbin_value_is_legal(
-          value_str, static_cast<size_t>(value->Length()))));
+      grpc_header_nonbin_value_is_legal(CreateSliceFromString(value))));
 }
 
 NAN_METHOD(MetadataKeyIsBinary) {
@@ -308,10 +306,8 @@ NAN_METHOD(MetadataKeyIsBinary) {
         "metadataKeyIsLegal's argument must be a string");
   }
   Local<String> key = Nan::To<String>(info[0]).ToLocalChecked();
-  Nan::Utf8String key_utf8_str(key);
-  char *key_str = *key_utf8_str;
   info.GetReturnValue().Set(static_cast<bool>(
-      grpc_is_binary_header(key_str, static_cast<size_t>(key->Length()))));
+      grpc_is_binary_header(CreateSliceFromString(key))));
 }
 
 static grpc_ssl_roots_override_result get_ssl_roots_override(

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -46,6 +46,7 @@
 #include "grpc/grpc_security.h"
 #include "grpc/support/log.h"
 #include "server_credentials.h"
+#include "slice.h"
 #include "timeval.h"
 
 namespace grpc {
@@ -99,10 +100,11 @@ class NewCallOp : public Op {
     }
     Local<Object> obj = Nan::New<Object>();
     Nan::Set(obj, Nan::New("call").ToLocalChecked(), Call::WrapStruct(call));
+    // TODO(murgatroid99): Use zero-copy string construction instead
     Nan::Set(obj, Nan::New("method").ToLocalChecked(),
-             Nan::New(details.method).ToLocalChecked());
+             CopyStringFromSlice(details.method));
     Nan::Set(obj, Nan::New("host").ToLocalChecked(),
-             Nan::New(details.host).ToLocalChecked());
+             CopyStringFromSlice(details.host));
     Nan::Set(obj, Nan::New("deadline").ToLocalChecked(),
              Nan::New<Date>(TimespecToMilliseconds(details.deadline))
                  .ToLocalChecked());
@@ -111,8 +113,7 @@ class NewCallOp : public Op {
     return scope.Escape(obj);
   }
 
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     return true;
   }
   bool IsFinalOp() {
@@ -139,8 +140,7 @@ class ServerShutdownOp : public Op {
     return Nan::New<External>(reinterpret_cast<void *>(server));
   }
 
-  bool ParseOp(Local<Value> value, grpc_op *out,
-               shared_ptr<Resources> resources) {
+  bool ParseOp(Local<Value> value, grpc_op *out) {
     return true;
   }
   bool IsFinalOp() {
@@ -207,8 +207,7 @@ void Server::ShutdownServer() {
 
     grpc_server_shutdown_and_notify(
         this->wrapped_server, GetCompletionQueue(),
-        new struct tag(new Callback(**shutdown_callback), ops.release(),
-                       shared_ptr<Resources>(nullptr), NULL));
+        new struct tag(new Callback(**shutdown_callback), ops.release(), NULL));
     grpc_server_cancel_all_calls(this->wrapped_server);
     CompletionQueueNext();
     this->wrapped_server = NULL;
@@ -261,7 +260,7 @@ NAN_METHOD(Server::RequestCall) {
       GetCompletionQueue(),
       GetCompletionQueue(),
       new struct tag(new Callback(info[0].As<Function>()), ops.release(),
-                     shared_ptr<Resources>(nullptr), NULL));
+                     NULL));
   if (error != GRPC_CALL_OK) {
     return Nan::ThrowError(nanErrorWithCode("requestCall failed", error));
   }
@@ -314,7 +313,7 @@ NAN_METHOD(Server::TryShutdown) {
   grpc_server_shutdown_and_notify(
       server->wrapped_server, GetCompletionQueue(),
       new struct tag(new Nan::Callback(info[0].As<Function>()), ops.release(),
-                     shared_ptr<Resources>(nullptr), NULL));
+                     NULL));
   CompletionQueueNext();
 }
 

--- a/src/node/ext/slice.cc
+++ b/src/node/ext/slice.cc
@@ -1,0 +1,102 @@
+/*
+ *
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <node.h>
+#include <nan.h>
+#include <grpc/slice.h>
+#include <grpc/support/alloc.h>
+
+#include "slice.h"
+#include "byte_buffer.h"
+
+namespace grpc {
+namespace node {
+
+using Nan::Persistent;
+
+using v8::Local;
+using v8::String;
+using v8::Value;
+
+namespace {
+void SliceFreeCallback(char *data, void *hint) {
+  grpc_slice *slice = reinterpret_cast<grpc_slice*>(hint);
+  grpc_slice_unref(*slice);
+  delete slice;
+}
+
+void string_destroy_func(void *user_data) {
+  delete reinterpret_cast<Nan::Utf8String*>(user_data);
+}
+
+void buffer_destroy_func(void *user_data) {
+  delete reinterpret_cast<PersistentValue*>(user_data);
+}
+} // namespace
+
+grpc_slice CreateSliceFromString(const Local<String> source) {
+  Nan::HandleScope scope;
+  Nan::Utf8String *utf8_value = new Nan::Utf8String(source);
+  return grpc_slice_new_with_user_data(**utf8_value, source->Length(),
+                                       string_destroy_func, utf8_value);
+}
+
+grpc_slice CreateSliceFromBuffer(const Local<Value> source) {
+  // Prerequisite: ::node::Buffer::HasInstance(source)
+  Nan::HandleScope scope;
+  return grpc_slice_new_with_user_data(::node::Buffer::Data(source),
+                                       ::node::Buffer::Length(source),
+                                       buffer_destroy_func,
+                                       new PersistentValue(source));
+}
+Local<String> CopyStringFromSlice(const grpc_slice slice) {
+  Nan::EscapableHandleScope scope;
+  if (GRPC_SLICE_LENGTH(slice) == 0) {
+    return scope.Escape(Nan::EmptyString());
+  }
+  return scope.Escape(Nan::New<String>(
+      const_cast<char *>(reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(slice))),
+      GRPC_SLICE_LENGTH(slice)).ToLocalChecked());
+}
+
+Local<Value> CreateBufferFromSlice(const grpc_slice slice) {
+  Nan::EscapableHandleScope scope;
+  grpc_slice *slice_ptr = new grpc_slice;
+  *slice_ptr = grpc_slice_ref(slice);
+  return scope.Escape(MakeFastBuffer(Nan::NewBuffer(
+      const_cast<char *>(reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(*slice_ptr))),
+      GRPC_SLICE_LENGTH(*slice_ptr), SliceFreeCallback, slice_ptr).ToLocalChecked()));
+}
+
+}  // namespace node
+}  // namespace grpc

--- a/src/node/ext/slice.h
+++ b/src/node/ext/slice.h
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <node.h>
+#include <nan.h>
+#include <grpc/slice.h>
+
+namespace grpc {
+namespace node {
+
+typedef Nan::Persistent<v8::Value, Nan::CopyablePersistentTraits<v8::Value>> PersistentValue;
+
+grpc_slice CreateSliceFromString(const v8::Local<v8::String> source);
+
+grpc_slice CreateSliceFromBuffer(const v8::Local<v8::Value> source);
+
+v8::Local<v8::String> CopyStringFromSlice(const grpc_slice slice);
+
+v8::Local<v8::Value> CreateBufferFromSlice(const grpc_slice slice);
+
+}  // namespace node
+}  // namespace grpc

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.c
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.c
@@ -202,6 +202,7 @@ grpc_slice_slice_type grpc_slice_slice_import;
 grpc_slice_hash_type grpc_slice_hash_import;
 grpc_slice_is_equivalent_type grpc_slice_is_equivalent_import;
 grpc_slice_dup_type grpc_slice_dup_import;
+grpc_slice_to_c_string_type grpc_slice_to_c_string_import;
 grpc_slice_buffer_init_type grpc_slice_buffer_init_import;
 grpc_slice_buffer_destroy_type grpc_slice_buffer_destroy_import;
 grpc_slice_buffer_add_type grpc_slice_buffer_add_import;
@@ -490,6 +491,7 @@ void grpc_rb_load_imports(HMODULE library) {
   grpc_slice_hash_import = (grpc_slice_hash_type) GetProcAddress(library, "grpc_slice_hash");
   grpc_slice_is_equivalent_import = (grpc_slice_is_equivalent_type) GetProcAddress(library, "grpc_slice_is_equivalent");
   grpc_slice_dup_import = (grpc_slice_dup_type) GetProcAddress(library, "grpc_slice_dup");
+  grpc_slice_to_c_string_import = (grpc_slice_to_c_string_type) GetProcAddress(library, "grpc_slice_to_c_string");
   grpc_slice_buffer_init_import = (grpc_slice_buffer_init_type) GetProcAddress(library, "grpc_slice_buffer_init");
   grpc_slice_buffer_destroy_import = (grpc_slice_buffer_destroy_type) GetProcAddress(library, "grpc_slice_buffer_destroy");
   grpc_slice_buffer_add_import = (grpc_slice_buffer_add_type) GetProcAddress(library, "grpc_slice_buffer_add");

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -557,6 +557,9 @@ extern grpc_slice_is_equivalent_type grpc_slice_is_equivalent_import;
 typedef grpc_slice(*grpc_slice_dup_type)(grpc_slice a);
 extern grpc_slice_dup_type grpc_slice_dup_import;
 #define grpc_slice_dup grpc_slice_dup_import
+typedef char *(*grpc_slice_to_c_string_type)(grpc_slice s);
+extern grpc_slice_to_c_string_type grpc_slice_to_c_string_import;
+#define grpc_slice_to_c_string grpc_slice_to_c_string_import
 typedef void(*grpc_slice_buffer_init_type)(grpc_slice_buffer *sb);
 extern grpc_slice_buffer_init_type grpc_slice_buffer_init_import;
 #define grpc_slice_buffer_init grpc_slice_buffer_init_import


### PR DESCRIPTION
The extension also now does not copy data passed to or from core except for slices from core that need to be converted to the JavaScript `String` type.