### PR TITLE
Paper-over Python errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ coverage
 # python compiled objects
 *.pyc
 
-#eclipse project files
+# eclipse project files
 .cproject
 .project
 .settings
@@ -110,3 +110,6 @@ bazel-genfiles
 bazel-grpc
 bazel-out
 bazel-testlogs
+
+# Debug output
+gdb.txt

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pxd.pxi
@@ -77,6 +77,8 @@ cdef class Slice:
   cdef void _assign_slice(self, grpc_slice new_slice) nogil
   @staticmethod
   cdef Slice from_slice(grpc_slice slice)
+  @staticmethod
+  cdef bytes bytes_from_slice(grpc_slice slice)
 
 
 cdef class ByteBuffer:
@@ -113,7 +115,10 @@ cdef class Metadatum:
 cdef class Metadata:
 
   cdef grpc_metadata_array c_metadata_array
+  cdef bint owns_metadata_slices
   cdef object metadata
+  cdef void _claim_slice_ownership(self) nogil
+  cdef void _drop_slice_ownership(self) nogil
 
 
 cdef class Operation:

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -576,6 +576,8 @@ def _handle_with_method_handler(rpc_event, method_handler, thread_pool):
 
 
 def _handle_call(rpc_event, generic_handlers, thread_pool):
+  if not rpc_event.success:
+    return None
   if rpc_event.request_call_details.method is not None:
     method_handler = _find_method_handler(rpc_event, generic_handlers)
     if method_handler is None:


### PR DESCRIPTION
@nathanielmanistaatgoogle There are a few failures in the metadata tests, e.g.
```
Testing gRPC Python...
SUCCESS       unit._metadata_test.MetadataTest.testStreamStream
Running       unit._metadata_test.MetadataTest.testStreamUnary
FAILURE       unit._metadata_test.MetadataTest.testStreamUnary
Running       unit._metadata_test.MetadataTest.testUnaryStream
SUCCESS       unit._metadata_test.MetadataTest.testUnaryStream
Running       unit._metadata_test.MetadataTest.testUnaryUnary
SUCCESS       unit._metadata_test.MetadataTest.testUnaryUnary
4 tests finished:
	3 successful
	1 unsuccessful
	0 skipped
	0 expected failures
	0 unexpected successes
Interrupted Tests:
	[]

Errors/Failures: 
unit._metadata_test.MetadataTest.testStreamUnary
traceback:
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.4/unittest/case.py", line 577, in run
    testMethod()
  File "/usr/local/google/home/atash/src/grpc/src/python/grpcio_tests/tests/unit/_metadata_test.py", line 199, in testStreamUnary
    _SERVER_INITIAL_METADATA, call.initial_metadata()))
  File "/usr/lib/python3.4/unittest/case.py", line 654, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true
```

Thoughts?