### PR TITLE
Drain CQ after shutdown

### DIFF
--- a/test/cpp/server/server_cq_test.cc
+++ b/test/cpp/server/server_cq_test.cc
@@ -43,6 +43,10 @@ static void BuildAndDeleteService() {
   server = builder.BuildAndStart();
   server->Shutdown();
   cq->Shutdown();
+  void* ignored_tag;
+  bool ignored_ok;
+  while (cq->Next(&ignored_tag, &ignored_ok))
+    ;
 }
 
 TEST(Foo, First) { BuildAndDeleteService(); }


### PR DESCRIPTION
A loop full of draining makes the memory go down