### PR TITLE
Fix stream compression bug

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -301,9 +301,10 @@ grpc_error *grpc_chttp2_data_parser_parse(grpc_exec_ctx *exec_ctx, void *parser,
     GPR_ASSERT(s->frame_storage.length == 0);
     grpc_slice_ref_internal(slice);
     grpc_slice_buffer_add(&s->unprocessed_incoming_frames_buffer, slice);
-    GRPC_CLOSURE_RUN(exec_ctx, s->on_next, GRPC_ERROR_NONE);
-    s->on_next = NULL;
     s->unprocessed_incoming_frames_decompressed = false;
+    grpc_closure *c = s->on_next;
+    s->on_next = NULL;
+    GRPC_CLOSURE_RUN(exec_ctx, c, GRPC_ERROR_NONE);
   } else {
     grpc_slice_ref_internal(slice);
     grpc_slice_buffer_add(&s->frame_storage, slice);


### PR DESCRIPTION
* Set `s->unprocessed_incoming_frames_decompressed = false` before closure is run
* Nullify `s->on_next` before it is run