### PR TITLE
Fix clang format installation

### DIFF
--- a/templates/tools/dockerfile/clang_format.include
+++ b/templates/tools/dockerfile/clang_format.include
@@ -1,6 +1,5 @@
 RUN apt-get update && apt-get -y install wget xz-utils
 RUN wget http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz
 RUN tar xf clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz
-ENV PATH=clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
+RUN ln -s /clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin/clang-format /usr/local/bin/clang-format
 ENV CLANG_FORMAT=clang-format
-

--- a/tools/dockerfile/grpc_clang_format/Dockerfile
+++ b/tools/dockerfile/grpc_clang_format/Dockerfile
@@ -17,9 +17,8 @@ FROM debian:jessie
 RUN apt-get update && apt-get -y install wget xz-utils
 RUN wget http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz
 RUN tar xf clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz
-ENV PATH=clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
+RUN ln -s /clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin/clang-format /usr/local/bin/clang-format
 ENV CLANG_FORMAT=clang-format
-
 
 ADD clang_format_all_the_things.sh /
 CMD ["echo 'Run with tools/distrib/clang_format_code.sh'"]

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -103,9 +103,8 @@ RUN ./bazel-0.4.4-installer-linux-x86_64.sh
 RUN apt-get update && apt-get -y install wget xz-utils
 RUN wget http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz
 RUN tar xf clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz
-ENV PATH=clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin:$PATH
+RUN ln -s /clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin/clang-format /usr/local/bin/clang-format
 ENV CLANG_FORMAT=clang-format
-
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc


### PR DESCRIPTION
For https://github.com/grpc/grpc/pull/13255.

Reasons you had trouble in #13255:
1. setting env PATH in the dockerfile works for `tools/distrib/clang_format_code.sh`, but it doesn't work for `tools/run_tests/run_tests.py -l sanity --use_docker`. IMHO, the reason is that run_tests.py copies the current environment variables from the parent when running the images (so that you can use tracing and other settings), which overwrites the PATH setting and you end up with "command not found: clang-format". Creating a symlink instead works file (see the diff).

2. after updating the dockerimages, things will work locally, but in order to make things work on kokoro, you need to push the updated testing base images to dockerhub (kokoro uses a new VM for each run, which prevents docker from using cache and rebuilding all the images takes too much time). To update the images, you need to run
`tools/dockerfile/push_testing_images.sh`, which will upload all updated images.
I ran that scripts and now things should be working fine on kokoro. 