### PR TITLE
fix build

### DIFF
--- a/src/core/lib/json/json_object_loader.h
+++ b/src/core/lib/json/json_object_loader.h
@@ -51,11 +51,11 @@
 //     int b;
 //     static const JsonLoaderInterface* JsonLoader() {
 //       // Note: Field names must be string constants; they are not copied.
-//       static const auto loader = JsonObjectLoader<Foo>()
+//       static const auto* loader = JsonObjectLoader<Foo>()
 //           .Field("a", &Foo::a)
 //           .Field("b", &Foo::b)
 //           .Finish();
-//       return &loader;
+//       return loader;
 //     }
 //     // Optional; omit if no post-processing needed.
 //     void JsonPostLoad(const Json& source, ErrorList* errors) { ++a; }
@@ -110,7 +110,7 @@ class LoaderInterface {
                         ErrorList* errors) const = 0;
 
  protected:
-  ~LoaderInterface() = default;
+  virtual ~LoaderInterface() = default;
 };
 
 // Loads a scalar (string or number).
@@ -119,7 +119,7 @@ class LoadScalar : public LoaderInterface {
   void LoadInto(const Json& json, void* dst, ErrorList* errors) const override;
 
  protected:
-  ~LoadScalar() = default;
+  ~LoadScalar() override = default;
 
  private:
   // true if we're loading a number, false if we're loading a string.
@@ -134,7 +134,7 @@ class LoadScalar : public LoaderInterface {
 // Load a number.
 class LoadNumber : public LoadScalar {
  protected:
-  ~LoadNumber() = default;
+  ~LoadNumber() override = default;
 
  private:
   bool IsNumber() const override;
@@ -143,7 +143,7 @@ class LoadNumber : public LoadScalar {
 // Load a duration
 class LoadDuration : public LoadScalar {
  protected:
-  ~LoadDuration() = default;
+  ~LoadDuration() override = default;
 
  private:
   bool IsNumber() const override;
@@ -155,7 +155,7 @@ class LoadDuration : public LoadScalar {
 template <typename T>
 class TypedLoadNumber : public LoadNumber {
  protected:
-  ~TypedLoadNumber() = default;
+  ~TypedLoadNumber() override = default;
 
  private:
   void LoadInto(const std::string& value, void* dst,
@@ -169,7 +169,7 @@ class TypedLoadNumber : public LoadNumber {
 // Load a string.
 class LoadString : public LoadScalar {
  protected:
-  ~LoadString() = default;
+  ~LoadString() override = default;
 
  private:
   bool IsNumber() const override;
@@ -183,7 +183,7 @@ class LoadVector : public LoaderInterface {
   void LoadInto(const Json& json, void* dst, ErrorList* errors) const override;
 
  protected:
-  ~LoadVector() = default;
+  ~LoadVector() override = default;
 
  private:
   virtual void LoadOne(const Json& json, void* dst,
@@ -196,7 +196,7 @@ class LoadOptional : public LoaderInterface {
   void LoadInto(const Json& json, void* dst, ErrorList* errors) const override;
 
  protected:
-  ~LoadOptional() = default;
+  ~LoadOptional() override = default;
 
  private:
   virtual void LoadOne(const Json& json, void* dst,
@@ -209,7 +209,7 @@ class LoadMap : public LoaderInterface {
   void LoadInto(const Json& json, void* dst, ErrorList* errors) const override;
 
  protected:
-  ~LoadMap() = default;
+  ~LoadMap() override = default;
 
  private:
   virtual void LoadOne(const Json& json, const std::string& name, void* dst,
@@ -295,10 +295,8 @@ class AutoLoader<std::map<std::string, T>> final : public LoadMap {
 // Simply keeps a static AutoLoader<T> and returns a pointer to that.
 template <typename T>
 const LoaderInterface* LoaderForType() {
-  static const AutoLoader<T> loader;
-  static_assert(std::is_trivially_destructible<decltype(loader)>::value,
-                "AutoLoader type is not trivially destructible");
-  return &loader;
+  static const auto* loader = new AutoLoader<T>();
+  return loader;
 }
 
 // Element describes one typed field to be loaded from a JSON object.
@@ -397,8 +395,8 @@ class JsonObjectLoader final {
                   "Only initial loader step can have kElemCount==0.");
   }
 
-  FinishedJsonObjectLoader<T, kElemCount> Finish() const {
-    return FinishedJsonObjectLoader<T, kElemCount>(elements_);
+  FinishedJsonObjectLoader<T, kElemCount>* Finish() const {
+    return new FinishedJsonObjectLoader<T, kElemCount>(elements_);
   }
 
   template <typename U>

--- a/test/core/json/json_object_loader_test.cc
+++ b/test/core/json/json_object_loader_test.cc
@@ -40,16 +40,16 @@ struct TestStruct1 {
   absl::optional<int32_t> e;
 
   static const JsonLoaderInterface* JsonLoader() {
-    static const auto loader = JsonObjectLoader<TestStruct1>()
-                                   .Field("a", &TestStruct1::a)
-                                   .OptionalField("b", &TestStruct1::b)
-                                   .OptionalField("c", &TestStruct1::c)
-                                   .Field("x", &TestStruct1::x)
-                                   .OptionalField("d", &TestStruct1::d)
-                                   .OptionalField("e", &TestStruct1::e)
-                                   .OptionalField("j", &TestStruct1::j)
-                                   .Finish();
-    return &loader;
+    static const auto* loader = JsonObjectLoader<TestStruct1>()
+                                    .Field("a", &TestStruct1::a)
+                                    .OptionalField("b", &TestStruct1::b)
+                                    .OptionalField("c", &TestStruct1::c)
+                                    .Field("x", &TestStruct1::x)
+                                    .OptionalField("d", &TestStruct1::d)
+                                    .OptionalField("e", &TestStruct1::e)
+                                    .OptionalField("j", &TestStruct1::j)
+                                    .Finish();
+    return loader;
   }
 };
 
@@ -59,12 +59,12 @@ struct TestStruct2 {
   TestStruct1 c;
 
   static const JsonLoaderInterface* JsonLoader() {
-    static const auto loader = JsonObjectLoader<TestStruct2>()
-                                   .Field("a", &TestStruct2::a)
-                                   .Field("b", &TestStruct2::b)
-                                   .OptionalField("c", &TestStruct2::c)
-                                   .Finish();
-    return &loader;
+    static const auto* loader = JsonObjectLoader<TestStruct2>()
+                                    .Field("a", &TestStruct2::a)
+                                    .Field("b", &TestStruct2::b)
+                                    .OptionalField("c", &TestStruct2::c)
+                                    .Finish();
+    return loader;
   }
 };
 
@@ -73,11 +73,11 @@ struct TestStruct3 {
   std::map<std::string, int32_t> b;
 
   static const JsonLoaderInterface* JsonLoader() {
-    static const auto loader = JsonObjectLoader<TestStruct3>()
-                                   .Field("a", &TestStruct3::a)
-                                   .Field("b", &TestStruct3::b)
-                                   .Finish();
-    return &loader;
+    static const auto* loader = JsonObjectLoader<TestStruct3>()
+                                    .Field("a", &TestStruct3::a)
+                                    .Field("b", &TestStruct3::b)
+                                    .Finish();
+    return loader;
   }
 };
 
@@ -89,14 +89,14 @@ struct TestPostLoadStruct1 {
   Duration d;
 
   static const JsonLoaderInterface* JsonLoader() {
-    static const auto loader = JsonObjectLoader<TestPostLoadStruct1>()
-                                   .Field("a", &TestPostLoadStruct1::a)
-                                   .OptionalField("b", &TestPostLoadStruct1::b)
-                                   .OptionalField("c", &TestPostLoadStruct1::c)
-                                   .Field("x", &TestPostLoadStruct1::x)
-                                   .OptionalField("d", &TestPostLoadStruct1::d)
-                                   .Finish();
-    return &loader;
+    static const auto* loader = JsonObjectLoader<TestPostLoadStruct1>()
+                                    .Field("a", &TestPostLoadStruct1::a)
+                                    .OptionalField("b", &TestPostLoadStruct1::b)
+                                    .OptionalField("c", &TestPostLoadStruct1::c)
+                                    .Field("x", &TestPostLoadStruct1::x)
+                                    .OptionalField("d", &TestPostLoadStruct1::d)
+                                    .Finish();
+    return loader;
   }
 
   void JsonPostLoad(const Json& source, ErrorList* errors) { ++a; }


### PR DESCRIPTION
Looks like the compiler wants the dtors to be virtual:

https://source.cloud.google.com/results/invocations/08c3c623-2c1d-4e4f-8291-5759cd37764e/log

However, making the dtors virtual means that the objects are no longer trivially destructible, so I've switched to using dynamic allocation for the static objects.